### PR TITLE
feat(tric) skip fixuid script on non-linux OSes

### DIFF
--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -36,6 +36,11 @@ function setup_tric_env( $root_dir ) {
 	// Set the current run context.
 	putenv( 'TRIBE_TRIC=1' );
 
+	if ( ! os() !== 'Linux' ) {
+		// Do not fix file modes on non-linux hosts.
+		putenv( 'FIXUID=0' );
+	}
+
 	// Load the distribution version configuration file, the version-controlled one.
 	load_env_file( $root_dir . '/.env.tric' );
 
@@ -263,7 +268,9 @@ function teardown_stack() {
  * Rebuilds the tric stack.
  */
 function rebuild_stack() {
+	echo "Building the stack images...\n\n";
 	tric_realtime()( [ 'build' ] );
+	echo light_cyan( "\nStack images built.\n\n" );
 }
 
 /**
@@ -302,4 +309,13 @@ function tric_info() {
 
 		echo colorize( "  - <light_cyan>{$key}</light_cyan>: {$value}\n" );
 	}
+}
+
+/**
+ * Updates the stack images by pulling the latest version of each.
+ */
+function update_stack_images() {
+	echo "Updating the stack images...\n\n";
+	tric_realtime()( [ 'pull', '--include-deps' ] );
+	echo light_cyan( "\n\nStack images updated.\n" );
 }

--- a/dev/test/_containers/npm/docker-entrypoint.sh
+++ b/dev/test/_containers/npm/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 
 # This file is just a proxy to call the `npm` binary that will, but, take care of fixing file mode issues before.
 
-eval $( fixuid )
+# If the `FIXUID` env var is set to `1`, default value, then fix UIDs.
+test "${FIXUID:-1}" != "0" && eval "$( fixuid )"
 
 npm --prefix /project "$@"

--- a/dev/tric
+++ b/dev/tric
@@ -31,6 +31,7 @@ use function Tribe\Test\tric_info;
 use function Tribe\Test\tric_process;
 use function Tribe\Test\tric_realtime;
 use function Tribe\Test\tric_target;
+use function Tribe\Test\update_stack_images;
 use function Tribe\Test\write_env_file;
 
 // Set up the argument parsing function.
@@ -71,6 +72,7 @@ Available commands:
 <light_cyan>shell</light_cyan>        Opens a shell in a stack service, defaults to the 'codeception' one.
 <light_cyan>cli</light_cyan>          Runs a wp-cli command in the stack.
 <light_cyan>reset</light_cyan>        Resets {$cli_name} to the initial state as configured by the env files.
+<light_cyan>update</light_cyan>       Updates the tool and the images used in its services.
 
 <yellow>Info:</yellow>
 <light_cyan>config</light_cyan>       Prints the stack configuration as interpolated from the environment.
@@ -506,6 +508,19 @@ switch ( $args( 'subcommand', 'help' ) ) {
 	case 'info':
 		setup_id();
 		tric_info();
+		break;
+
+	case 'update':
+		if ( $is_help ) {
+			echo "Updates the tool and the images used in its services.\n";
+			echo PHP_EOL;
+			echo colorize( "usage: <light_cyan>${argv[0]} update</light_cyan>\n" );
+			break;
+		}
+
+		rebuild_stack();
+		update_stack_images();
+
 		break;
 }
 

--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -40,6 +40,7 @@ services:
       # The port, in the container, is not the default `80` to allow non root users to bind (listen) to it.
       - "${WORDPRESS_HTTP_PORT:-8888}:80"
     environment:
+      FIXUID: "${FIXUID:-1}"
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
       # This db is created by the db container at startup, no need to create it.
@@ -74,6 +75,7 @@ services:
     networks:
       - tric
     environment:
+      FIXUID: "${FIXUID:-1}"
       # Configure this to debug the tests with XDebug.
       # Map the `dev/_wordpress` directory to `/var/www/html' directory in your IDE of choice.
       # Map the `dev/_plugins` directory to `/plugins' directory in your IDE of choice.
@@ -113,6 +115,7 @@ services:
     extra_hosts:
       - "wordpress.test:172.${TRIC_TEST_SUBNET:-28}.1.1"
     environment:
+      FIXUID: "${FIXUID:-1}"
       # Set these values to allow the container to look wordpress up.
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
@@ -143,6 +146,8 @@ services:
   composer:
     image: lucatume/composer:php7.2
     user: "${DOCKER_RUN_UID:-0}:${DOCKER_RUN_GID:-0}"
+    environment:
+      FIXUID: "${FIXUID:-1}"
     volumes:
       # Set the current plugin as project.
       - ./_plugins/${TRIC_CURRENT_PROJECT:-test}:/project
@@ -154,6 +159,8 @@ services:
       context: test/_containers/npm
     image: tric_npm
     user: "${DOCKER_RUN_UID:-0}:${DOCKER_RUN_GID:-0}"
+    environment:
+      FIXUID: "${FIXUID:-1}"
     volumes:
       # Set the current plugin as project.
       - ./_plugins/${TRIC_CURRENT_PROJECT:-test}:/project


### PR DESCRIPTION
This fix puts a `FIXUID=0` env var that will be parsed from `tric`
custom containers and the `composer` and `codeception` containers used
by the stack to skip the `fixuid` script when not running on Linux.

Default behavior, to make sure CI keeps working is to **not skip**; on
systems that would not require it, the fix simply wasted time, but it's
not harmful.

The PR also adds the `tric update` command to pull the latest version of external images and re-build the ones that require it.

fix #19