### PR TITLE
Allow for the toggling off of interactivity to support CI

### DIFF
--- a/dev/.env.tric
+++ b/dev/.env.tric
@@ -23,6 +23,9 @@ TRIC_GITHUB_COMPANY_HANDLE=moderntribe
 # The path from which to read plugins from.
 TRIC_PLUGINS_DIR=./_plugins
 
+# The interactive mode of tric. Set to `0` to avoid prompts during CLI operations.
+TRIC_INTERACTIVE=1
+
 # XDebug configuration parameters, will apply to the `cli`, `wordpress` and `codeception` services.
 # ===============================
 # The IDE key used to identify connection requests coming from the services.

--- a/dev/setup/src/commands/interactive.php
+++ b/dev/setup/src/commands/interactive.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Activates and deactivated interactive mode. While deactivated, prompts will be suppressed and default values will be automatically selected.\n";
+	echo PHP_EOL;
+	echo colorize( "signature: <light_cyan>${argv[0]} interactive (on|off|status)</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>${argv[0]} interactive on</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>${argv[0]} interactive off</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>${argv[0]} interactive status</light_cyan>\n" );
+	return;
+}
+
+$interactive_args = args( [ 'toggle' ], $args( '...' ), 0 );
+
+tric_handle_interactive( $interactive_args );
+
+echo colorize( "\n\nToggle this setting by using: <light_cyan>tric interactive [on|off]</light_cyan>\n" );
+echo colorize( "- on:  commands with prompts will prompt for input interactively.\n" );
+echo colorize( "- off: commands with prompts will NOT prompt and will use defaults.\n" );

--- a/dev/setup/src/tric.php
+++ b/dev/setup/src/tric.php
@@ -349,6 +349,40 @@ function tric_wp_dir( $path = '' ) {
 }
 
 /**
+ * Prints the current interactive status to screen.
+ */
+function interactive_status() {
+	$enabled = getenv( 'TRIC_INTERACTIVE' );
+
+	echo 'Interactive status is: ' . ( $enabled ? light_cyan( 'on' ) : magenta( 'off' ) ) . PHP_EOL;
+}
+
+/**
+ * Handles the interactive command request.
+ *
+ * @param callable $args The closure that will produce the current interactive request arguments.
+ */
+function tric_handle_interactive( callable $args ) {
+	$run_settings_file = dev( '/.env.tric.run' );
+	$toggle            = $args( 'toggle', 'on' );
+
+	if ( 'status' === $toggle ) {
+		interactive_status();
+
+		return;
+	}
+
+	$value = 'on' === $toggle ? 1 : 0;
+	echo 'Interactive status: ' . ( $value ? light_cyan( 'on' ) : magenta( 'off' ) );
+
+	if ( $value === (int) getenv( 'TRIC_INTERACTIVE' ) ) {
+		return;
+	}
+
+	write_env_file( $run_settings_file, [ 'TRIC_INTERACTIVE' => $value ], true );
+}
+
+/**
  * Prints the current XDebug status to screen.
  */
 function xdebug_status() {
@@ -368,19 +402,19 @@ function xdebug_status() {
 
 	echo 'IDE Key: ' . light_cyan( $ide_key ) . PHP_EOL;
 	echo colorize( PHP_EOL . "You can override these values in the <light_cyan>.env.tric.local" .
-	               "</light_cyan> file or by using the " .
-	               "<light_cyan>'xdebug (host|key|port) <value>'</light_cyan> command." ) . PHP_EOL;
+			"</light_cyan> file or by using the " .
+			"<light_cyan>'xdebug (host|key|port) <value>'</light_cyan> command." ) . PHP_EOL;
 
 
 	echo PHP_EOL . 'Set up, in your IDE, a server with the following parameters to debug PHP requests:' . PHP_EOL;
 	echo 'IDE key, or server name: ' . light_cyan( $ide_key ) . PHP_EOL;
 	echo 'Host: ' . light_cyan( 'http://localhost' . ( $localhost_port === '80' ? '' : ':' . $localhost_port ) ) . PHP_EOL;
 	echo colorize( 'Path mapping (host => server): <light_cyan>'
-	               . tric_plugins_dir()
-	               . '</light_cyan> => <light_cyan>/var/www/html/wp-content/plugins</light_cyan>' ) . PHP_EOL;
+			. tric_plugins_dir()
+			. '</light_cyan> => <light_cyan>/var/www/html/wp-content/plugins</light_cyan>' ) . PHP_EOL;
 	echo colorize( 'Path mapping (host => server): <light_cyan>'
-	               . tric_wp_dir()
-	               . '</light_cyan> => <light_cyan>/var/www/html</light_cyan>' );
+		. tric_wp_dir()
+		. '</light_cyan> => <light_cyan>/var/www/html</light_cyan>' );
 
 	$default_mask = ( tric_wp_dir() === dev( '/_wordpress' ) ) + 2 * ( tric_plugins_dir() === dev( '/_plugins' ) );
 
@@ -388,12 +422,12 @@ function xdebug_status() {
 		case 1:
 			echo PHP_EOL . PHP_EOL;
 			echo yellow( 'Note: tric is using the default WordPress directory and a different plugins directory: ' .
-			             'set path mappings correctly and keep that in mind.' );
+				'set path mappings correctly and keep that in mind.' );
 			break;
 		case 2:
 			echo PHP_EOL . PHP_EOL;
 			echo yellow( 'Note: tric is using the default plugins directory and a different WordPress directory: ' .
-			             'set path mappings correctly and keep that in mind.' );
+				'set path mappings correctly and keep that in mind.' );
 			break;
 		case 3;
 		default:

--- a/dev/setup/src/utils.php
+++ b/dev/setup/src/utils.php
@@ -477,6 +477,8 @@ function ssh_auth_sock() {
  * @return string|null The user answer or the default value if the user did not provide an answer to the question.
  */
 function ask( $question, $default = null ) {
+	$is_interactive = getenv( 'TRIC_INTERACTIVE' );
+
 	$prompt = colorize( "<bold>{$question}</bold>" );
 
 	if ( null !== $default && '' !== $default ) {
@@ -489,7 +491,11 @@ function ask( $question, $default = null ) {
 		$is_boolean = true;
 	}
 
-	$value = readline( $prompt . ' ' );
+	if ( empty( $is_interactive ) ) {
+		$value = $default;
+	} else {
+		$value = readline( $prompt . ' ' );
+	}
 
 	if ( $is_boolean ) {
 		return preg_match( '/^y/i', $value );

--- a/dev/tric
+++ b/dev/tric
@@ -62,6 +62,7 @@ Available commands:
 <light_cyan>config</light_cyan>         Prints the stack configuration as interpolated from the environment.
 <light_cyan>debug</light_cyan>          Activates or deactivates {$cli_name} debug output or returns the current debug status.
 <light_cyan>help</light_cyan>           Displays this help message.
+<light_cyan>interactive</light_cyan>    Activates or deactivates interactivity of {$cli_name} commands.
 <light_cyan>logs</light_cyan>           Displays the current stack logs.
 <light_cyan>info</light_cyan>           Displays information about the tric tool.
 
@@ -98,6 +99,7 @@ switch ( $subcommand ) {
 	case 'here':
 	case 'info':
 	case 'init':
+	case 'interactive':
 	case 'logs':
 	case 'npm':
 	case 'reset':


### PR DESCRIPTION
This adds the command: `tric interactive [on|off|status]`

It defaults to `on`. Setting interactivity to `off` will suppress prompts and use the default response.

🎥 http://p.tri.be/ZDxDvl

This addresses #23