### PR TITLE
feat(tric) allow specifying target branch for init, fixes #45

### DIFF
--- a/dev/setup/src/commands/init.php
+++ b/dev/setup/src/commands/init.php
@@ -11,13 +11,16 @@ namespace Tribe\Test;
 if ( $is_help ) {
 	echo "Initializes a plugin for use in tric.\n";
 	echo PHP_EOL;
-	echo colorize( "signature: <light_cyan>${argv[0]} init <plugin></light_cyan>\n" );
+	echo colorize( "signature: <light_cyan>${argv[0]} init <plugin> [<branch>]</light_cyan>\n" );
 	echo colorize( "example: <light_cyan>${argv[0]} init the-events-calendar</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>${argv[0]} init event-tickets release/B20.04</light_cyan>\n" );
 	return;
 }
 
-$sub_args = args( [ 'plugin' ], $args( '...' ), 0 );
+$sub_args = args( [ 'plugin', 'branch' ], $args( '...' ), 0 );
 $plugin   = $sub_args( 'plugin', false );
+// The default branch might not be `master`.
+$branch = $sub_args( 'branch' );
 
 // If a plugin isn't passed as an argument, the target is the current plugin being used.
 if ( empty( $plugin ) ) {
@@ -25,7 +28,13 @@ if ( empty( $plugin ) ) {
 	echo light_cyan( "Using {$plugin}\n" );
 }
 
-clone_plugin( $plugin );
+clone_plugin( $plugin, $branch );
+
+// Since the `init` command is also the one that will rebuild assets, we need to switch branch if required.
+if ( null !== $branch ) {
+	switch_plugin_branch( $branch, $plugin );
+}
+
 setup_plugin_tests( $plugin );
 
 tric_maybe_run_composer_install( $plugin );


### PR DESCRIPTION
fixes #45

This PR adds support for a branch to the `init` command.

While running `tric init event-tickets` is still possible, it will use, as it did before, the default repository branch.  
This PR allows running the `init` command, and with it the `composer` and `npm` tasks, directly during init phase with
an API like this:

```bash
tric init event-tickets release/G20.04
```

The command will try to change the branch locally first, and then will try to pull from each plugin repository remote.

The command is recursing on sub-modules too to make sure the `composer` and `npm` commands will build on the correct
version of `common` if the plugins contains it.

[Screencap](https://drive.google.com/open?id=15whrSiUbHgkkcTYS1IUfceJl4b3se0Y7&authuser=luca@tri.be&usp=drive_fs)