### PR TITLE
fix(tric) use PHP 7.0 for Composer

### DIFF
--- a/dev/tric-stack.yml
+++ b/dev/tric-stack.yml
@@ -156,7 +156,7 @@ services:
       - function-mocker-cache:/tmp/function-mocker
 
   composer:
-    image: lucatume/composer:php7.2
+    image: lucatume/composer:php7.0
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
       FIXUID: "${FIXUID:-1}"


### PR DESCRIPTION
Our current Travis CI builds use PHP version 7.0.
This means that any `composer.lock` file we generate should be 7.0
compatible.
This fix changes the PHP version used, in the `tric` stack, by the
`composer` service, to make sure we pull PHP 7.0 compatible code and
will push, as a result, a PHP 7.0 compatible `composer.lock` file.