### PR TITLE
Fix "sh: resize: command not found" in Konsole

### DIFF
--- a/dev/setup/shell.php
+++ b/dev/setup/shell.php
@@ -63,27 +63,15 @@ function get_terminal_lines_cols() {
 			$columns = $m['val'];
 		}
 	} else {
-		$resize_exists = ! empty( exec( "command -v resize" ) );
+		$tput_exists = ! empty( exec( "command -v tput" ) );
 
-		if ( ! $resize_exists ) {
-			// Probably not running a Xterm compatible terminal, bail.
+		if ( ! $tput_exists ) {
+			// We can't get the lines and columns on this terminal, bail.
 			return [ $lines, $columns ];
 		}
 
-		exec( 'resize', $output, $status );
-
-		if ( 0 !== $status ) {
-			// We cannot fetch information, bail.
-			return [ $lines, $columns ];
-		}
-
-		foreach ( $output as $line ) {
-			if ( ! preg_match( '/(?<key>(COLUMNS|LINES))=(?<val>[0-9]+)/', $line, $m ) ) {
-				continue;
-			}
-			$key    = strtolower( $m['key'] );
-			${$key} = (int) $m['val'];
-		}
+		$lines   = abs( intval( exec( 'tput lines' ) ) );
+		$columns = abs( intval( exec( 'tput cols' ) ) );
 	}
 
 	return [ $lines, $columns ];

--- a/dev/setup/shell.php
+++ b/dev/setup/shell.php
@@ -63,15 +63,35 @@ function get_terminal_lines_cols() {
 			$columns = $m['val'];
 		}
 	} else {
-		$tput_exists = ! empty( exec( "command -v tput" ) );
+		// Lines
+		exec( 'tput lines', $lines, $status );
 
-		if ( ! $tput_exists ) {
-			// We can't get the lines and columns on this terminal, bail.
+		if ( $status !== 0 ) {
+			// tput lines can't give us the lines on this terminal, bail.
 			return [ $lines, $columns ];
 		}
 
-		$lines   = abs( intval( exec( 'tput lines' ) ) );
-		$columns = abs( intval( exec( 'tput cols' ) ) );
+		if ( ! empty( $lines ) && is_numeric( $lines[0] ) ) {
+			$lines = abs( intval( $lines[0] ) );
+		} else {
+			// Unexpected value, bail.
+			return [ $lines, $columns ];
+		}
+
+		// Columns
+		exec( 'tput cols', $columns, $status );
+
+		if ( $status !== 0 ) {
+			// tput cols can't give us the columns on this terminal, bail.
+			return [ $lines, $columns ];
+		}
+
+		if ( ! empty( $columns ) && is_numeric( $columns[0] ) ) {
+			$columns = abs( intval( $columns[0] ) );
+		} else {
+			// Unexpected value, bail.
+			return [ $lines, $columns ];
+		}
 	}
 
 	return [ $lines, $columns ];

--- a/dev/setup/shell.php
+++ b/dev/setup/shell.php
@@ -63,6 +63,13 @@ function get_terminal_lines_cols() {
 			$columns = $m['val'];
 		}
 	} else {
+		$resize_exists = ! empty( exec( "command -v resize" ) );
+
+		if ( ! $resize_exists ) {
+			// Probably not running a Xterm compatible terminal, bail.
+			return [ $lines, $columns ];
+		}
+
 		exec( 'resize', $output, $status );
 
 		if ( 0 !== $status ) {


### PR DESCRIPTION
This PR skips the execution of `resize` if the host terminal does not support it.

Links:
- https://invisible-island.net/xterm/
- https://invisible-island.net/xterm/manpage/resize.html
- https://www.slant.co/versus/2445/2446/~xterm_vs_konsole